### PR TITLE
Entertainment starting routes

### DIFF
--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -1,4 +1,5 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from motor.motor_asyncio import AsyncIOMotorClient
 
 class CommonSettings(BaseSettings):
     APP_NAME: str = "NTFX_APP"
@@ -19,7 +20,12 @@ class DatabaseSettings(BaseSettings):
 
 
 class Settings(CommonSettings, ServerSettings, DatabaseSettings):
-    pass
+    async def initiate_database(self):
+        client = AsyncIOMotorClient(self.DB_URI)
+        return client
 
 
 settings = Settings()
+
+
+

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from schemas.entertainment import EntertainmentMedia, EntertainmentCollection
+
+async def add_entertainment_media(entertainment_media: EntertainmentMedia, db) -> EntertainmentMedia:
+    # Create new entertainment_media
+    new_entertainment_media = await db.entertainment.insert_one(
+        entertainment_media.model_dump(by_alias=True, exclude=["id"])
+    )
+
+    # if inserted_id to validate creation 
+    if new_entertainment_media.inserted_id:
+        # Fetch the inserted document, will return the ObjectId
+        created_media = await db.entertainment.find_one({"_id": new_entertainment_media.inserted_id})
+        # Populate EntertainmentMedia model with the created_media
+        media_instance = EntertainmentMedia(**created_media)
+        return media_instance
+    else:
+        raise ValueError('Failed to create new entertainment media')
+
+async def get_all_movies(db) -> EntertainmentCollection:
+    movie_list = []
+    cursor = db.entertainment.find({"category": "Movie"})
+    for document in await cursor.to_list(length=100):
+        movie_list.append(EntertainmentMedia(**document))
+    return movie_list
+
+
+        

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,13 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from config import settings
 from starlette.responses import RedirectResponse
 from motor.motor_asyncio import AsyncIOMotorClient
+
+from schemas import entertainment
+from contextlib import asynccontextmanager
+from database import *
+
 import uvicorn
 
 app = FastAPI(
@@ -10,13 +15,24 @@ app = FastAPI(
     version = settings.VERSION
 )
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Establish the database connection
+    global db_client
+    db_client = await settings.initiate_database()
+    yield
+    # Close the database connection
+    if db_client:
+        db_client.close()
+
+app = FastAPI(lifespan=lifespan)
+
 async def get_database():
-    client = AsyncIOMotorClient(settings.DB_URI)
-    try:
-        db = client[settings.DB_NAME]
-        yield db
-    finally:
-        client.close()
+    if db_client is None:
+        raise RuntimeError("Database client not initialized")
+    return db_client[settings.DB_NAME]
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -36,10 +52,38 @@ async def main_function():
     return RedirectResponse(url="/docs/")
 
 
-# if __name__ == "__main__":
-#     uvicorn.run(
-#         "main:app",
-#         host=settings.HOST,
-#         reload=settings.DEBUG_MODE,
-#         port=settings.PORT,
-#     )
+@app.post("/entertainment/media/")
+async def create_entertainment_media(entertainment_media: entertainment.EntertainmentMedia) -> EntertainmentMedia:
+    db = await get_database()
+    if db is not None:
+        new_entertainment_media = await add_entertainment_media(entertainment_media, db)
+    else:
+        raise HTTPException(status_code=500, detail="Database connection failed")
+
+    if new_entertainment_media:
+       return new_entertainment_media
+    else:
+        raise HTTPException(status_code=500, detail="Failed to create item")
+
+@app.get("/movies")
+async def all_movies() -> EntertainmentCollection:
+    db = await get_database()
+    if db is not None:
+        all_movies = await get_all_movies(db)
+    else:
+        raise HTTPException(status_code=500, detail="Database connection failed")
+    
+    if all_movies is not None:
+        return EntertainmentCollection(movies=all_movies)
+    else:
+        raise HTTPException(status_code=404, detail="Failed to find movies")
+
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "main:app",
+        host=settings.HOST,
+        reload=settings.DEBUG_MODE,
+        port=settings.PORT,
+    )

--- a/backend/app/schemas/entertainment.py
+++ b/backend/app/schemas/entertainment.py
@@ -1,0 +1,108 @@
+from pydantic import BaseModel, Field, BeforeValidator, ConfigDict
+# from typing_extensions import Annotated, Optional
+from typing import List, Optional, Annotated
+
+
+class TrendingThumbnails(BaseModel):
+    """
+    Container for the TRENDING thumbnail URLs.
+    """
+    model_config = ConfigDict(from_attributes=True)
+    
+    # Basic fields
+    small: str = Field(description="The URL to the SMALL trending photo.")
+    large: str = Field(description="The URL to the LARGE trending photo.")
+
+class RegularThumbnails(BaseModel):
+    """
+    Container for the REGULAR thumbnail URLs.
+    """
+    model_config = ConfigDict(from_attributes=True)
+
+    # Basic fields
+    small: str = Field(description="The URL to the SMALL regular photo.")
+    medium: str = Field(description="The URL to the MEDIUM regular photo.")
+    large: str = Field(description="The URL to the LARGE regular photo.")
+
+
+class Thumbnail(BaseModel):
+    """
+    Container for the Thumbnail URLs.
+    """
+    model_config = ConfigDict(from_attributes=True)
+
+    # Declare the trending and regular as RegularThumbnails and TrendingThumbnails items
+    regular: RegularThumbnails
+    # can be empty
+    trending: Optional[TrendingThumbnails] = None
+    
+
+# Represents an ObjectId field in the database.
+# It will be represented as a `str` on the model so that it can be serialized to JSON.
+PyObjectId = Annotated[str, BeforeValidator(str)]
+
+class EntertainmentPublicSettings(BaseModel):
+    """
+    Container for the relationships between the entertainment piece and it's trending attribute. One could put more here, but matching the data.json
+
+    This is prone to change, so it's separated from the entertainment piece.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    # Basic fields
+    isTrending: bool = Field(default= False,description="Whether the entertainment media is trending or not")
+
+
+class EntertainmentMedia(BaseModel):
+    """
+    Container for the piece of Entertainment, name is prone to change.
+    """
+    # The primary key for the EntertainmentMedia, stored as a `str` on the instance.
+    # This will be aliased to `_id` when sent to MongoDB,
+    # but provided as `id` in the API requests and responses.
+    id: Optional[PyObjectId] = Field(alias='_id', default=None)
+
+    # Basic fields
+    title: str = Field(description="The entertainment medias title.")
+    thumbnail: Thumbnail = Field(description="The collection of URLs this media holds, categorized by regular and trending.")
+    year: int = Field(description="The year this entertainment piece was released.")
+    category: str = Field(description="Whether the entertainment piece is a MOVIE or TELEVISION SERIES.")
+
+    public_entertainment_settings: EntertainmentPublicSettings = Field(description="Is the entertainment piece trending?")
+
+    model_config = ConfigDict(
+        populate_by_name = True,
+        json_schema_extra = {
+            "example": {
+                "title": "Beyond Earth",
+                "thumbnail": {
+                    "trending": {
+                                    "small": "./assets/thumbnails/beyond-earth/trending/small.jpg",
+                                    "large": "./assets/thumbnails/beyond-earth/trending/large.jpg"
+                                },
+                    "regular": {
+                                    "small": "./assets/thumbnails/beyond-earth/regular/small.jpg",
+                                    "medium": "./assets/thumbnails/beyond-earth/regular/medium.jpg",
+                                    "large": "./assets/thumbnails/beyond-earth/regular/large.jpg"
+                                }
+                },
+               "year": 2019,
+                "category": "Movie",
+                "rating": "PG",
+                "public_entertainment_settings": { 'isTrending' : True }
+            }
+        }
+        )
+
+        
+
+
+class EntertainmentCollection(BaseModel):
+    """
+    A container holding a list of `EntertainmentMedia` instances.
+
+    This exists because providing a top-level array in a JSON response can be a [vulnerability](https://haacked.com/archive/2009/06/25/json-hijacking.aspx/)
+    """
+
+    movies: List[EntertainmentMedia]


### PR DESCRIPTION
Within this PR:

1) Routes for posting entertainment / Getting all movies
2) CRUD inside database.py for posting entertainment + getting all movies
3) Schema for the entertainment model. Renamed from EntertainmentPiece to EntertainmentMedia
4) Config initiating DB for lifespan in FastAPI

Movie by ID to come, getting stuck with find_one returning nothing? 

https://motor.readthedocs.io/en/stable/tutorial-asyncio.html#getting-a-single-document-with-find-one

I think it's the ObjectId and BSON would save us here, (I THINK).